### PR TITLE
Update airplane dev commands

### DIFF
--- a/admin_panel/README.md
+++ b/admin_panel/README.md
@@ -5,6 +5,6 @@
 - Navigate to the admin_panel directory: `cd admin_panel`
 - If you plan on using this on a different database resource than the demo database, change the `[Demo DB]` resource in `list_customer_orders.task.yaml`, `search_customers.task.yaml`, `update_customer_contact_name.task.yaml`, and `update_ship_address.task.yaml` to the name of your own database resource
 - Deploy tasks: `airplane deploy tasks --yes`
-- Develop your template locally: `airplane dev --editor`
+- Develop your template locally: `airplane dev --editor --env ''`
 - Deploy your view: `airplane deploy .`
 - Visit the docs to learn more about how to build views: https://docs.airplane.dev/views/getting-started

--- a/customer_insights_dashboard/README.md
+++ b/customer_insights_dashboard/README.md
@@ -5,6 +5,6 @@
 - Navigate to the customer_insights_dashboard directory: `cd customer_insights_dashboard`
 - If you plan on using this on a different database resource than the demo database, change the `[Demo DB]`  resource in `list_top_products.task.yaml`, `list_customers.task.yaml`, `get_orders_per_week.task.yaml`, `get_products_per_week.task.yaml`, and `get_customers_per_week.task.yaml` to your own database resource
 - Deploy tasks: `airplane deploy tasks --yes`
-- Develop your view locally: `airplane views dev`
+- Develop your template locally: `airplane dev --editor --env ''`
 - Deploy your view: `airplane deploy .`
 - Visit the docs to learn more about how to build views: https://docs.airplane.dev/views/getting-started

--- a/database_issues_alert/README.md
+++ b/database_issues_alert/README.md
@@ -3,7 +3,7 @@
 ## Next steps
 
 - Navigate to the database_issues_alert directory: `cd database_issues_alert`
-- Develop your template locally: `airplane dev --editor`
+- Develop your template locally: `airplane dev --editor --env ''`
 - Enable our [Slack integration](https://docs.airplane.dev/platform/slack-integration) on your team
 - Uncomment and edit the slack channel you want to send the alert to in alert_on_database_issues.task.yaml (where it says `INSERT_SLACK_CHANNEL_HERE`)
 - If you plan on using this on a different database resource than the demo database, change the `demo_db` resource in alert_on_database_issues.task.yaml to your own database resource's slug

--- a/github_pr_dashboard/README.md
+++ b/github_pr_dashboard/README.md
@@ -4,7 +4,7 @@
 
 - Navigate to the github_pr_dashboard directory: `cd github_pr_dashboard`
 - Deploy tasks: `airplane deploy tasks --yes`
-- Develop your template locally: `airplane dev --editor`
+- Develop your template locally: `airplane dev --editor --env ''`
 - To use your own GitHub API Key, get your GitHub API keys by following this guide: https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token. Using yoiur own GitHub API key will allow you to query private repositories and increase your rate limiting.
   - Create a config variable in Airplane for `GITHUB_API_KEY`: https://docs.airplane.dev/platform/configs
   - Uncomment out `GITHUB_API_KEY` environment variable in `tasks/list_github_pull_requests.task.yaml`.

--- a/stripe_billing_dashboard/README.md
+++ b/stripe_billing_dashboard/README.md
@@ -4,7 +4,7 @@
 
 - Navigate to the stripe_billing_dashboard directory: `cd stripe_billing_dashboard`
 - Deploy tasks: `airplane deploy tasks --yes`
-- Develop your template locally: `airplane dev --editor`
+- Develop your template locally: `airplane dev --editor --env ''`
 - To use your own Stripe API Key, get your Stripe API keys by following this guide: https://stripe.com/docs/keys#obtain-api-keys
   - Create a config variable in Airplane for `STRIPE_SECRET_KEY`: https://docs.airplane.dev/platform/configs
   - Uncomment out `STRIPE_SECRET_KEY` environment variable in `list_stripe_customers.task.yaml`, `lookup_charges_for_stripe_customer.task.yaml`, `lookup_stripe_customer.task.yaml`, and `lookup_stripe_customer.task.yaml`

--- a/support_ticket_dashboard/README.md
+++ b/support_ticket_dashboard/README.md
@@ -4,7 +4,7 @@
 
 - Navigate to the support_ticket_dashboard directory: `cd support_ticket_dashboard`
 - Deploy tasks: `airplane deploy tasks --yes`
-- Develop your template locally: `airplane dev --editor`
+- Develop your template locally: `airplane dev --editor --env ''`
 - To use your own Intercom auth token and Linear API key:
   - Intercom:
     - Get your Intercom auth token by following this guide: https://developers.intercom.com/building-apps/docs/authentication-types


### PR DESCRIPTION
Updates the `airplane dev --editor` usage since we recently made a change that requires the user to explicitly provide an `--env` flag if they want their local view to run against a remote task. Changes all the commands to `airplane dev --editor --env ''` (where the empty string indicates the default environment).

Tested with all templates here: https://docs.airplane.dev/templates