### PR TITLE
Update command to develop templates

### DIFF
--- a/admin_panel/README.md
+++ b/admin_panel/README.md
@@ -4,7 +4,7 @@
 
 - Navigate to the admin_panel directory: `cd admin_panel`
 - If you plan on using this on a different database resource than the demo database, change the `[Demo DB]` resource in `list_customer_orders.task.yaml`, `search_customers.task.yaml`, `update_customer_contact_name.task.yaml`, and `update_ship_address.task.yaml` to the name of your own database resource
+- Develop your template locally: `airplane dev`
 - Deploy tasks: `airplane deploy tasks --yes`
-- Develop your template locally: `airplane views dev`
 - Deploy your view: `airplane deploy .`
 - Visit the docs to learn more about how to build views: https://docs.airplane.dev/views/getting-started

--- a/admin_panel/README.md
+++ b/admin_panel/README.md
@@ -5,6 +5,5 @@
 - Navigate to the admin_panel directory: `cd admin_panel`
 - If you plan on using this on a different database resource than the demo database, change the `[Demo DB]` resource in `list_customer_orders.task.yaml`, `search_customers.task.yaml`, `update_customer_contact_name.task.yaml`, and `update_ship_address.task.yaml` to the name of your own database resource
 - Develop your template locally: `airplane dev`
-- Deploy tasks: `airplane deploy tasks --yes`
-- Deploy your view: `airplane deploy .`
+- Deploy your tasks and view: `airplane deploy --yes`
 - Visit the docs to learn more about how to build views: https://docs.airplane.dev/views/getting-started

--- a/customer_insights_dashboard/README.md
+++ b/customer_insights_dashboard/README.md
@@ -4,7 +4,7 @@
 
 - Navigate to the customer_insights_dashboard directory: `cd customer_insights_dashboard`
 - If you plan on using this on a different database resource than the demo database, change the `[Demo DB]`  resource in `list_top_products.task.yaml`, `list_customers.task.yaml`, `get_orders_per_week.task.yaml`, `get_products_per_week.task.yaml`, and `get_customers_per_week.task.yaml` to your own database resource
+- Develop your template locally: `airplane dev`
 - Deploy tasks: `airplane deploy tasks --yes`
-- Develop your template locally: `airplane views dev`
 - Deploy your view: `airplane deploy .`
 - Visit the docs to learn more about how to build views: https://docs.airplane.dev/views/getting-started

--- a/customer_insights_dashboard/README.md
+++ b/customer_insights_dashboard/README.md
@@ -5,6 +5,5 @@
 - Navigate to the customer_insights_dashboard directory: `cd customer_insights_dashboard`
 - If you plan on using this on a different database resource than the demo database, change the `[Demo DB]`  resource in `list_top_products.task.yaml`, `list_customers.task.yaml`, `get_orders_per_week.task.yaml`, `get_products_per_week.task.yaml`, and `get_customers_per_week.task.yaml` to your own database resource
 - Develop your template locally: `airplane dev`
-- Deploy tasks: `airplane deploy tasks --yes`
-- Deploy your view: `airplane deploy .`
+- Deploy your tasks and view: `airplane deploy --yes`
 - Visit the docs to learn more about how to build views: https://docs.airplane.dev/views/getting-started

--- a/customer_onboarding_dashboard/README.md
+++ b/customer_onboarding_dashboard/README.md
@@ -4,6 +4,5 @@
 - Navigate to the customer_onboarding_dashboard directory: `cd customer_onboarding_dashboard`
 - If you plan on using this on a different database resource than the demo database, change the `[Demo DB]`  resource in `create_account.task.yaml`, `create_user.task.yaml`, and `list_new_accounts.task.yaml`, `update_region.task.yaml` to your own database resource
 - Develop your view locally: `airplane dev`
-- Deploy tasks: `airplane deploy tasks --yes`
-- Deploy your view: `airplane deploy .`
+- Deploy your tasks and view: `airplane deploy --yes`
 - Visit the docs to learn more about how to build views: https://docs.airplane.dev/views/getting-started

--- a/customer_onboarding_dashboard/README.md
+++ b/customer_onboarding_dashboard/README.md
@@ -3,7 +3,7 @@
 ## Next steps
 - Navigate to the customer_onboarding_dashboard directory: `cd customer_onboarding_dashboard`
 - If you plan on using this on a different database resource than the demo database, change the `[Demo DB]`  resource in `create_account.task.yaml`, `create_user.task.yaml`, and `list_new_accounts.task.yaml`, `update_region.task.yaml` to your own database resource
+- Develop your view locally: `airplane dev`
 - Deploy tasks: `airplane deploy tasks --yes`
-- Develop your view locally: `airplane views dev`
 - Deploy your view: `airplane deploy .`
 - Visit the docs to learn more about how to build views: https://docs.airplane.dev/views/getting-started

--- a/database_issues_alert/README.md
+++ b/database_issues_alert/README.md
@@ -3,8 +3,8 @@
 ## Next steps
 
 - Navigate to the database_issues_alert directory: `cd database_issues_alert`
-- Develop your template locally: `airplane dev --editor --env ''`
+- Develop your template locally: `airplane dev`
 - Enable our [Slack integration](https://docs.airplane.dev/platform/slack-integration) on your team
 - Uncomment and edit the Slack channel you want to send the alert to in alert_on_database_issues.task.yaml (where it says `INSERT_SLACK_CHANNEL_HERE`)
 - If you plan on using this on a different database resource than the demo database, change the `demo_db` resource in alert_on_database_issues.task.yaml to your own database resource's slug
-- Deploy your task and schedule: `airplane deploy . --yes`
+- Deploy your task and schedule: `airplane deploy --yes`

--- a/github_pr_dashboard/README.md
+++ b/github_pr_dashboard/README.md
@@ -5,7 +5,8 @@
 - Navigate to the github_pr_dashboard directory: `cd github_pr_dashboard`
 - Develop your template locally: `airplane dev`
 - To use your own GitHub API Key, get your GitHub API keys by following this guide: https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token. Using your own GitHub API key will allow you to query private repositories and increase your rate limiting.
-  - Create a local config variable in Airplane for `GITHUB_API_KEY`: https://docs.airplane.dev/dev-lifecycle/dev-config-file#add-a-config-variable
+  - Create a config variable in Airplane for `GITHUB_API_KEY`: https://docs.airplane.dev/platform/configs
+  - Also add the config variable to your dev config file in order to develop tasks locally: https://docs.airplane.dev/dev-lifecycle/dev-config-file#add-a-config-variable
   - Uncomment out `GITHUB_API_KEY` environment variable in `tasks/list_github_pull_requests.task.yaml`.
 - Deploy your tasks and view: `airplane deploy --yes`
 - Visit the docs to learn more about how to build views: https://docs.airplane.dev/views/getting-started

--- a/github_pr_dashboard/README.md
+++ b/github_pr_dashboard/README.md
@@ -3,11 +3,11 @@
 ## Next steps
 
 - Navigate to the github_pr_dashboard directory: `cd github_pr_dashboard`
-- Deploy tasks: `airplane deploy tasks --yes`
-- Develop your template locally: `airplane views dev`
+- Develop your template locally: `airplane dev`
 - To use your own GitHub API Key, get your GitHub API keys by following this guide: https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token. Using your own GitHub API key will allow you to query private repositories and increase your rate limiting.
   - Create a config variable in Airplane for `GITHUB_API_KEY`: https://docs.airplane.dev/platform/configs
   - Uncomment out `GITHUB_API_KEY` environment variable in `tasks/list_github_pull_requests.task.yaml`.
   - Re-deploy your tasks: `airplane deploy tasks --yes`
+- Deploy tasks: `airplane deploy tasks --yes`
 - Deploy your view: `airplane deploy .`
 - Visit the docs to learn more about how to build views: https://docs.airplane.dev/views/getting-started

--- a/github_pr_dashboard/README.md
+++ b/github_pr_dashboard/README.md
@@ -5,9 +5,7 @@
 - Navigate to the github_pr_dashboard directory: `cd github_pr_dashboard`
 - Develop your template locally: `airplane dev`
 - To use your own GitHub API Key, get your GitHub API keys by following this guide: https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token. Using your own GitHub API key will allow you to query private repositories and increase your rate limiting.
-  - Create a config variable in Airplane for `GITHUB_API_KEY`: https://docs.airplane.dev/platform/configs
+  - Create a local config variable in Airplane for `GITHUB_API_KEY`: https://docs.airplane.dev/dev-lifecycle/dev-config-file#add-a-config-variable
   - Uncomment out `GITHUB_API_KEY` environment variable in `tasks/list_github_pull_requests.task.yaml`.
-  - Re-deploy your tasks: `airplane deploy tasks --yes`
-- Deploy tasks: `airplane deploy tasks --yes`
-- Deploy your view: `airplane deploy .`
+- Deploy your tasks and view: `airplane deploy --yes`
 - Visit the docs to learn more about how to build views: https://docs.airplane.dev/views/getting-started

--- a/python_selenium_example/README.md
+++ b/python_selenium_example/README.md
@@ -5,6 +5,6 @@ Simple task that demonstrates how to load a website in Python using [selenium](h
 ## Next steps
 
 - Navigate to the python_selenium_example directory: `cd python_selenium_example`
-- Run your task locally: `airplane dev selenium_example.task.yaml`
+- Run your task locally: `airplane dev`
 - Make any changes to the `selenium_example.py` script
-- Deploy your task: `airplane deploy . --yes`
+- Deploy your task: `airplane deploy --yes`

--- a/stripe_billing_dashboard/README.md
+++ b/stripe_billing_dashboard/README.md
@@ -5,7 +5,8 @@
 - Navigate to the stripe_billing_dashboard directory: `cd stripe_billing_dashboard`
 - Develop your template locally: `airplane dev`
 - To use your own Stripe API Key, get your Stripe API keys by following this guide: https://stripe.com/docs/keys#obtain-api-keys
-  - Create a local config variable in Airplane for `STRIPE_SECRET_KEY`: https://docs.airplane.dev/dev-lifecycle/dev-config-file#add-a-config-variable
+  - Create a config variable in Airplane for `STRIPE_SECRET_KEY`: https://docs.airplane.dev/platform/configs
+  - Also add the config variable to your dev config file in order to develop tasks locally: https://docs.airplane.dev/dev-lifecycle/dev-config-file#add-a-config-variable
   - Uncomment out `STRIPE_SECRET_KEY` environment variable in `list_stripe_customers.task.yaml`, `lookup_charges_for_stripe_customer.task.yaml`, `lookup_stripe_customer.task.yaml`, and `lookup_stripe_customer.task.yaml`
 - Deploy your tasks and view: `airplane deploy --yes`
 - Visit the docs to learn more about how to build views: https://docs.airplane.dev/views/getting-started

--- a/stripe_billing_dashboard/README.md
+++ b/stripe_billing_dashboard/README.md
@@ -5,9 +5,7 @@
 - Navigate to the stripe_billing_dashboard directory: `cd stripe_billing_dashboard`
 - Develop your template locally: `airplane dev`
 - To use your own Stripe API Key, get your Stripe API keys by following this guide: https://stripe.com/docs/keys#obtain-api-keys
-  - Create a config variable in Airplane for `STRIPE_SECRET_KEY`: https://docs.airplane.dev/platform/configs
+  - Create a local config variable in Airplane for `STRIPE_SECRET_KEY`: https://docs.airplane.dev/dev-lifecycle/dev-config-file#add-a-config-variable
   - Uncomment out `STRIPE_SECRET_KEY` environment variable in `list_stripe_customers.task.yaml`, `lookup_charges_for_stripe_customer.task.yaml`, `lookup_stripe_customer.task.yaml`, and `lookup_stripe_customer.task.yaml`
-  - Re-deploy your tasks: `airplane deploy tasks --yes`
-- Deploy tasks: `airplane deploy tasks --yes`
-- Deploy your view: `airplane deploy .`
+- Deploy your tasks and view: `airplane deploy --yes`
 - Visit the docs to learn more about how to build views: https://docs.airplane.dev/views/getting-started

--- a/stripe_billing_dashboard/README.md
+++ b/stripe_billing_dashboard/README.md
@@ -3,11 +3,11 @@
 ## Next steps
 
 - Navigate to the stripe_billing_dashboard directory: `cd stripe_billing_dashboard`
-- Deploy tasks: `airplane deploy tasks --yes`
-- Develop your template locally: `airplane views dev`
+- Develop your template locally: `airplane dev`
 - To use your own Stripe API Key, get your Stripe API keys by following this guide: https://stripe.com/docs/keys#obtain-api-keys
   - Create a config variable in Airplane for `STRIPE_SECRET_KEY`: https://docs.airplane.dev/platform/configs
   - Uncomment out `STRIPE_SECRET_KEY` environment variable in `list_stripe_customers.task.yaml`, `lookup_charges_for_stripe_customer.task.yaml`, `lookup_stripe_customer.task.yaml`, and `lookup_stripe_customer.task.yaml`
   - Re-deploy your tasks: `airplane deploy tasks --yes`
+- Deploy tasks: `airplane deploy tasks --yes`
 - Deploy your view: `airplane deploy .`
 - Visit the docs to learn more about how to build views: https://docs.airplane.dev/views/getting-started

--- a/support_ticket_dashboard/README.md
+++ b/support_ticket_dashboard/README.md
@@ -8,13 +8,15 @@
 - To use your own Intercom auth token and Linear API key:
   - Intercom:
     - Get your Intercom auth token by following this guide: https://developers.intercom.com/building-apps/docs/authentication-types
-    - Create a local config variable in Airplane for `INTERCOM_AUTH_TOKEN`: https://docs.airplane.dev/dev-lifecycle/dev-config-file#add-a-config-variable
+    - Create a config variable in Airplane for `INTERCOM_AUTH_TOKEN`: https://docs.airplane.dev/platform/configs
+    - Also add the config variable to your dev config file in order to develop tasks locally: https://docs.airplane.dev/dev-lifecycle/dev-config-file#add-a-config-variable
     - Uncomment `INTERCOM_AUTH_TOKEN` environment variable in `list_open_intercom_conversations.task.yaml`
     - Remove mock data in `list_open_intercom_conversations.ts`
     - Add your Intercom app ID to `ticketing_dashboard.view.tsx`
   - Linear:
     - Get your Linear API key here after logging in: https://linear.app/airplane/settings/api
-    - Create a local config variable in Airplane for `LINEAR_API_KEY`: https://docs.airplane.dev/dev-lifecycle/dev-config-file#add-a-config-variable
+    - Create a config variable in Airplane for `LINEAR_API_KEY`: https://docs.airplane.dev/platform/configs
+    - Also add the config variable to your dev config file in order to develop tasks locally: https://docs.airplane.dev/dev-lifecycle/dev-config-file#add-a-config-variable
     - Uncomment `LINEAR_API_KEY` environment variable in `list_linear_users.task.yaml`, `list_linear_teams.task.yaml`, and `create_linear_issue.task.yaml`
     - Remove mock data in `list_linear_users.ts`, `list_linear_teams.ts`, and `create_linear_issue.ts`
 

--- a/support_ticket_dashboard/README.md
+++ b/support_ticket_dashboard/README.md
@@ -4,21 +4,19 @@
 
 - Navigate to the support_ticket_dashboard directory: `cd support_ticket_dashboard`
 - Develop your template locally: `airplane dev`
+- Deploy your tasks and view: `airplane deploy --yes`
 - To use your own Intercom auth token and Linear API key:
   - Intercom:
     - Get your Intercom auth token by following this guide: https://developers.intercom.com/building-apps/docs/authentication-types
-    - Create a config variable in Airplane for `INTERCOM_AUTH_TOKEN`: https://docs.airplane.dev/platform/configs
+    - Create a local config variable in Airplane for `INTERCOM_AUTH_TOKEN`: https://docs.airplane.dev/dev-lifecycle/dev-config-file#add-a-config-variable
     - Uncomment `INTERCOM_AUTH_TOKEN` environment variable in `list_open_intercom_conversations.task.yaml`
     - Remove mock data in `list_open_intercom_conversations.ts`
     - Add your Intercom app ID to `ticketing_dashboard.view.tsx`
   - Linear:
     - Get your Linear API key here after logging in: https://linear.app/airplane/settings/api
-    - Create a config variable in Airplane for `LINEAR_API_KEY`: https://docs.airplane.dev/platform/configs
+    - Create a local config variable in Airplane for `LINEAR_API_KEY`: https://docs.airplane.dev/dev-lifecycle/dev-config-file#add-a-config-variable
     - Uncomment `LINEAR_API_KEY` environment variable in `list_linear_users.task.yaml`, `list_linear_teams.task.yaml`, and `create_linear_issue.task.yaml`
     - Remove mock data in `list_linear_users.ts`, `list_linear_teams.ts`, and `create_linear_issue.ts`
-  - Re-deploy tasks: `airplane deploy tasks --yes`
-- Deploy tasks: `airplane deploy tasks --yes`
-- Deploy your view: `airplane deploy .`
 
 ## Resources
 

--- a/support_ticket_dashboard/README.md
+++ b/support_ticket_dashboard/README.md
@@ -3,8 +3,7 @@
 ## Next steps
 
 - Navigate to the support_ticket_dashboard directory: `cd support_ticket_dashboard`
-- Deploy tasks: `airplane deploy tasks --yes`
-- Develop your template locally: `airplane views dev`
+- Develop your template locally: `airplane dev`
 - To use your own Intercom auth token and Linear API key:
   - Intercom:
     - Get your Intercom auth token by following this guide: https://developers.intercom.com/building-apps/docs/authentication-types
@@ -18,6 +17,7 @@
     - Uncomment `LINEAR_API_KEY` environment variable in `list_linear_users.task.yaml`, `list_linear_teams.task.yaml`, and `create_linear_issue.task.yaml`
     - Remove mock data in `list_linear_users.ts`, `list_linear_teams.ts`, and `create_linear_issue.ts`
   - Re-deploy tasks: `airplane deploy tasks --yes`
+- Deploy tasks: `airplane deploy tasks --yes`
 - Deploy your view: `airplane deploy .`
 
 ## Resources

--- a/support_ticket_dashboard/README.md
+++ b/support_ticket_dashboard/README.md
@@ -4,7 +4,6 @@
 
 - Navigate to the support_ticket_dashboard directory: `cd support_ticket_dashboard`
 - Develop your template locally: `airplane dev`
-- Deploy your tasks and view: `airplane deploy --yes`
 - To use your own Intercom auth token and Linear API key:
   - Intercom:
     - Get your Intercom auth token by following this guide: https://developers.intercom.com/building-apps/docs/authentication-types
@@ -19,6 +18,7 @@
     - Also add the config variable to your dev config file in order to develop tasks locally: https://docs.airplane.dev/dev-lifecycle/dev-config-file#add-a-config-variable
     - Uncomment `LINEAR_API_KEY` environment variable in `list_linear_users.task.yaml`, `list_linear_teams.task.yaml`, and `create_linear_issue.task.yaml`
     - Remove mock data in `list_linear_users.ts`, `list_linear_teams.ts`, and `create_linear_issue.ts`
+- Deploy your tasks and view: `airplane deploy --yes`
 
 ## Resources
 

--- a/user_impersonation_tool/README.md
+++ b/user_impersonation_tool/README.md
@@ -3,8 +3,7 @@
 ## Next steps
 
 - Navigate to the user_impersonation_tool directory: `cd user_impersonation_tool`
-- Deploy tasks: `airplane deploy tasks --yes`
-- Develop your template locally: `airplane views dev`
+- Develop your template locally: `airplane dev`
 - To use your own WorkOS API Key:
   - Get your Intercom auth token by following this guide: https://workos.com/docs/reference/api-keys
   - Create a config variable in Airplane for `WORKOS_API_KEY`: https://docs.airplane.dev/platform/configs
@@ -13,6 +12,7 @@
   - Add config variables to your dev config file in order to develop tasks locally: https://docs.airplane.dev/dev-lifecycle/dev-config-file#environment-variables
   - Re-deploy tasks: `airplane deploy tasks --yes`
 - Optionally, you can rewrite `generateSignInLink` to use your authentication provider of choice
+- Deploy tasks: `airplane deploy tasks --yes`
 - Deploy your view: `airplane deploy .`
 
 ## Resources

--- a/user_impersonation_tool/README.md
+++ b/user_impersonation_tool/README.md
@@ -6,14 +6,11 @@
 - Develop your template locally: `airplane dev`
 - To use your own WorkOS API Key:
   - Get your Intercom auth token by following this guide: https://workos.com/docs/reference/api-keys
-  - Create a config variable in Airplane for `WORKOS_API_KEY`: https://docs.airplane.dev/platform/configs
+  - Create a local config variable in Airplane for `WORKOS_API_KEY`: https://docs.airplane.dev/dev-lifecycle/dev-config-file#add-a-config-variable
   - Uncomment `WORKOS_API_KEY` environment variable in `impersonate.task.yaml`
   - Remove mock data in `impersonate.ts`
-  - Add config variables to your dev config file in order to develop tasks locally: https://docs.airplane.dev/dev-lifecycle/dev-config-file#environment-variables
-  - Re-deploy tasks: `airplane deploy tasks --yes`
 - Optionally, you can rewrite `generateSignInLink` to use your authentication provider of choice
-- Deploy tasks: `airplane deploy tasks --yes`
-- Deploy your view: `airplane deploy .`
+- Deploy your tasks and view: `airplane deploy --yes`
 
 ## Resources
 

--- a/user_impersonation_tool/README.md
+++ b/user_impersonation_tool/README.md
@@ -6,7 +6,8 @@
 - Develop your template locally: `airplane dev`
 - To use your own WorkOS API Key:
   - Get your Intercom auth token by following this guide: https://workos.com/docs/reference/api-keys
-  - Create a local config variable in Airplane for `WORKOS_API_KEY`: https://docs.airplane.dev/dev-lifecycle/dev-config-file#add-a-config-variable
+  - Create a config variable in Airplane for `WORKOS_API_KEY`: https://docs.airplane.dev/platform/configs
+  - Also add the config variable to your dev config file in order to develop tasks locally: https://docs.airplane.dev/dev-lifecycle/dev-config-file#add-a-config-variable
   - Uncomment `WORKOS_API_KEY` environment variable in `impersonate.task.yaml`
   - Remove mock data in `impersonate.ts`
 - Optionally, you can rewrite `generateSignInLink` to use your authentication provider of choice

--- a/views_getting_started/README.md
+++ b/views_getting_started/README.md
@@ -3,7 +3,7 @@
 ## Next steps
 
 1. Navigate to the getting_started directory: `cd views_getting_started`
-2. Deploy tasks: `airplane deploy tasks --yes`
-3. Develop your view locally: `airplane views dev`
+2. Develop your view locally: `airplane dev`
 4. Visit the getting started guide for Airplane Views to continue building your view: https://docs.airplane.dev/views/getting-started
+4. 2. Deploy tasks: `airplane deploy tasks --yes`
 5. Deploy your view: `airplane deploy .`

--- a/views_getting_started/README.md
+++ b/views_getting_started/README.md
@@ -5,5 +5,5 @@
 1. Navigate to the getting_started directory: `cd views_getting_started`
 2. Develop your view locally: `airplane dev`
 3. Visit the getting started guide for Airplane Views to continue building your view: https://docs.airplane.dev/views/getting-started
-4. 2. Deploy tasks: `airplane deploy tasks --yes`
+4. Deploy tasks: `airplane deploy tasks --yes`
 5. Deploy your view: `airplane deploy .`

--- a/views_getting_started/README.md
+++ b/views_getting_started/README.md
@@ -5,5 +5,4 @@
 1. Navigate to the getting_started directory: `cd views_getting_started`
 2. Develop your view locally: `airplane dev`
 3. Visit the getting started guide for Airplane Views to continue building your view: https://docs.airplane.dev/views/getting-started
-4. Deploy tasks: `airplane deploy tasks --yes`
-5. Deploy your view: `airplane deploy .`
+4. Deploy your tasks and view: `airplane deploy --yes`

--- a/views_getting_started/README.md
+++ b/views_getting_started/README.md
@@ -4,6 +4,6 @@
 
 1. Navigate to the getting_started directory: `cd views_getting_started`
 2. Develop your view locally: `airplane dev`
-4. Visit the getting started guide for Airplane Views to continue building your view: https://docs.airplane.dev/views/getting-started
+3. Visit the getting started guide for Airplane Views to continue building your view: https://docs.airplane.dev/views/getting-started
 4. 2. Deploy tasks: `airplane deploy tasks --yes`
 5. Deploy your view: `airplane deploy .`


### PR DESCRIPTION
Updates all the `airplane views dev` commands to use `airplane dev` (we don't need the `--studio` flag since that will be the default). Also moves the "Deploy tasks" instructions to be alongside the "Deploy view" instructions, since deploying tasks is no longer necessary to develop the template locally.

Depends on https://github.com/airplanedev/cli/pull/732