### PR TITLE
Change views version to exact match

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,10 @@ vendor
 
 yarn.lock
 package-lock.json
+
+# Airplane folders
 .airplane-view
+.airplane
 
 # Editors
 .idea/

--- a/admin_panel/package.json
+++ b/admin_panel/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "license": "MIT",
   "dependencies": {
-    "@airplane/views": "^1.6.0",
+    "@airplane/views": "1.11.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/customer_insights_dashboard/package.json
+++ b/customer_insights_dashboard/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "license": "MIT",
   "dependencies": {
-    "@airplane/views": "^1.6.0",
+    "@airplane/views": "1.11.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/customer_onboarding_dashboard/package.json
+++ b/customer_onboarding_dashboard/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "license": "MIT",
   "dependencies": {
-    "@airplane/views": "1.8.0",
+    "@airplane/views": "1.11.0",
     "airplane": "^0.2.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/feature_flagging_dashboard/package.json
+++ b/feature_flagging_dashboard/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "license": "MIT",
   "dependencies": {
-    "@airplane/views": "^1.8.3",
+    "@airplane/views": "1.11.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/github_pr_dashboard/package.json
+++ b/github_pr_dashboard/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "license": "MIT",
   "dependencies": {
-    "@airplane/views": "^1.6.0",
+    "@airplane/views": "1.11.0",
     "airplane": "^0.2.1",
     "octokit": "2.0.7",
     "react": "^18.2.0",

--- a/stripe_billing_dashboard/package.json
+++ b/stripe_billing_dashboard/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "license": "MIT",
   "dependencies": {
-    "@airplane/views": "^1.6.0",
+    "@airplane/views": "1.11.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "stripe": "10.8.0"

--- a/support_ticket_dashboard/package.json
+++ b/support_ticket_dashboard/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "license": "MIT",
   "dependencies": {
-    "@airplane/views": "^1.6.0",
+    "@airplane/views": "1.11.0",
     "@linear/sdk": "1.22.0",
     "intercom-client": "3.1.5",
     "react": "^18.2.0",

--- a/user_impersonation_tool/package.json
+++ b/user_impersonation_tool/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "license": "MIT",
   "dependencies": {
-    "@airplane/views": "^1.8.4",
+    "@airplane/views": "1.11.0",
     "@workos-inc/node": "~2.12.0",
     "airplane": "^0.2.0",
     "react": "^18.2.0",

--- a/user_impersonation_tool/user_impersonation/user_impersonation.view.tsx
+++ b/user_impersonation_tool/user_impersonation/user_impersonation.view.tsx
@@ -25,12 +25,14 @@ const UserImpersonation = () => {
   const dialogState = useComponentState();
   return (
     <Stack>
-      <Title>Impersonate a user</Title>
-      <Text>
-        🚨 Be cautious when impersonating users. Doing things inside a user's
-        account can lead to noticeable, irreversible changes! All impersonation
-        attempts are audited.
-      </Text>
+      <div>
+        <Title>Impersonate a user</Title>
+        <Text>
+          🚨 Be cautious when impersonating users. Doing things inside a user's
+          account can lead to noticeable, irreversible changes! All
+          impersonation attempts are audited.
+        </Text>
+      </div>
       <TextInput id={queryState.id} label="Search by ID, email, or team" />
       <Table<User>
         title="Users"

--- a/views_getting_started/package.json
+++ b/views_getting_started/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "license": "MIT",
   "dependencies": {
-    "@airplane/views": "^1.0.0",
+    "@airplane/views": "1.11.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },


### PR DESCRIPTION
Change views version to exact match so that:
* We enable renovate on templates to keep our templates up-to-date with the latest views version
* Users don't accidentally install a later version that we haven't tested yet

I bumped the version and tested each template on studio to verify that they all still work