### PR TITLE
Add datetime column types to admin panel

### DIFF
--- a/admin_panel/admin_dashboard/admin_dashboard.view.tsx
+++ b/admin_panel/admin_dashboard/admin_dashboard.view.tsx
@@ -132,8 +132,8 @@ const customersCols = [
 
 const ordersCols = [
   { accessor: "order_id", label: "Order ID" },
-  { accessor: "order_date", label: "Order date" },
-  { accessor: "shipped_date", label: "Shipped date" },
+  { accessor: "order_date", label: "Order date", type: "datetime" },
+  { accessor: "shipped_date", label: "Shipped date", type: "datetime" },
   { accessor: "freight", label: "Freight" },
   {
     accessor: "ship_address",


### PR DESCRIPTION
Formats it nicer in the table
<img width="402" alt="Screen Shot 2022-12-01 at 1 42 42 PM" src="https://user-images.githubusercontent.com/34196250/205134301-b69f3557-e71f-4f87-8ef7-f2c85ced3931.png">
