### PR TITLE
Fix airplane versions for templates

### DIFF
--- a/customer_onboarding_dashboard/package.json
+++ b/customer_onboarding_dashboard/package.json
@@ -4,7 +4,6 @@
   "license": "MIT",
   "dependencies": {
     "@airplane/views": "1.11.2",
-    "airplane": "^0.2.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/database_issues_alert/package.json
+++ b/database_issues_alert/package.json
@@ -5,6 +5,6 @@
   "main": "alert_on_database_issues.ts",
   "license": "MIT",
   "dependencies": {
-    "airplane": "^0.2.15"
+    "airplane": "0.2.25"
   }
 }

--- a/github_pr_dashboard/package.json
+++ b/github_pr_dashboard/package.json
@@ -4,7 +4,6 @@
   "license": "MIT",
   "dependencies": {
     "@airplane/views": "1.11.2",
-    "airplane": "^0.2.1",
     "octokit": "2.0.10",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/user_impersonation_tool/package.json
+++ b/user_impersonation_tool/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@airplane/views": "1.11.2",
     "@workos-inc/node": "~2.16.0",
-    "airplane": "^0.2.0",
+    "airplane": "0.2.25",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/user_impersonation_tool/package.json
+++ b/user_impersonation_tool/package.json
@@ -5,7 +5,6 @@
   "dependencies": {
     "@airplane/views": "1.11.2",
     "@workos-inc/node": "~2.16.0",
-    "airplane": "0.2.25",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },


### PR DESCRIPTION
- remove airplane dependency for templates not using it
- bump airplane dependency to latest for the one that is using it
- 

context is that deployments from renovate PR were failing bc airplane dependency was too low to meet the workflows min version

now deployments are passing - https://app.airplane.dev/deployments/dpl20221208zo7zi2nqbef?__env=prod


test plan: went and tested these 4 templates in studio and then deployed to prod and tested them