### PR TITLE
Add prBodyNotes with link to notion doc

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,7 @@
   "extends": ["config:base", "group:allNonMajor"],
   "ignoreDeps": ["highlight.run"],
   "labels": ["merge"],
+  "prBodyNotes": "If you are assigned as a reviewer, please help and promptly review this upgrade - [see docs](https://www.notion.so/airplanedev/Dependency-PRs-07a8a4f0570040a7965c2c1183fb87c8).",
   "reviewers": ["team:views"],
   "schedule": ["before 5am on Thursday"],
   "timezone": "America/New_York"


### PR DESCRIPTION
Adds a link to internal docs on handling renovate PRs

[_Created by Sourcegraph batch change `josh/renovate_prbody`._](https://airplane.sourcegraph.com/users/josh/batch-changes/renovate_prbody)